### PR TITLE
jic: fix order of arguments in error

### DIFF
--- a/jic
+++ b/jic
@@ -2580,7 +2580,7 @@ class Cache (object):
             # TODO: report error
             raise RuntimeError(
                 u'No server specified - please either '\
-                u'do `jic select server` or use -S switch')
+                u'do `jic server select` or use -S switch')
 
         self.srv_cfg = cfg.o.get('servers.' + self.srv_name)
 


### PR DESCRIPTION
Hi there.  Here's a very small patch to fix the error message displayed when no server is selected.  The command to select a server is "jic server select" not "jic select server".


Regards,

Tim.