### PR TITLE
jic: Import JIRAError from client module, instead of exceptions

### DIFF
--- a/jic
+++ b/jic
@@ -81,8 +81,7 @@ def vpr(string=u'', end=u'\n', flush=False):
             sys.stdout.flush()
 
 try:
-    from jira.client import JIRA
-    from jira.exceptions import JIRAError
+    from jira.client import JIRA, JIRAError
     from jira.resources import Comment, Component, Issue, IssueType, \
                                Project, Resolution, Status, User, \
                                Version, Worklog


### PR DESCRIPTION
Hi there.  I'm trying out jic with version 0.50 of the python-jira module and it's giving me an import exception.  It looks like the JIRAError has moved into the .client module from the .exceptions module.

Not sure whether this is the best fix - maybe it's better to rely on the __init__.py file and import JIRA and JIRAError from the top level.